### PR TITLE
Allow multiple user karma expressions in a single message

### DIFF
--- a/scripts/karma.coffee
+++ b/scripts/karma.coffee
@@ -45,9 +45,16 @@ module.exports = (robot) ->
   #   But not [user4--] :(
 
   robot.hear /\@?([\w.]+)(--|\+\+)/g, (msg) ->
+    seenUsernames = new Set()
     # user shouldn't be able to give themselves karma
     userKarmaExpressions = getUserKarmaExpressions(msg.match)
-      .filter((expr) -> expr.username != msg.message.user.name.toLowerCase())
+      .filter((expr) ->
+        # Only keep the first expression seen for the user
+        unless seenUsernames.has(expr.username)
+          seenUsernames.add(expr.username)
+          # don't let user adjust their own score
+          expr.username != msg.message.user.name.toLowerCase())
+      .filter((expr, index) -> expr.username)
 
     for { username, operator } in userKarmaExpressions
       # get the current karma points


### PR DESCRIPTION
Reworked the regex to search for all instances of: `<username><operator>`

Where:
- <username> may be prefixed with an "@" symbol
- <operator> maye either be  "--" or "++"

I convert the matches to `UserKarmaExpression` structs to make working with the tokens a little simpler.

```
UserKarmaExpression {
  type: "UserKarmaExpression"
  username: (lowercased) string
  operator: "--" or "++"
}
```

---
Examples using `bin/hubot` script. (current username is `Shell`).

<details>
<summary>General usage</summary>
<pre>

Hubot> @userA++ is the best!
Ho brah, usera 1 da kine! :shaka:

Hubot> Mahalo userA++!
usera goin 1 fo 2 da kine! :shaka:

Hubot> Thanks @userA++ @userB++ @userC++!
Ho brah, usera 3 da kine! :shaka:
Ho brah, userb 1 da kine! :shaka:
Ho brah, userc 1 da kine! :shaka:

Hubot> But not user4-- :(
Ho brah, user4 -1 da kine!

Hubot> I can't give Shell++ points ¯\\\_(ツ)\_/¯
Hubot> Or shell++ points ¯\\\_(ツ)\_/¯
Hubot></pre>
</details>

<details>
<summary>Just take the first karma expression per user per message</summary>
<pre>

Hubot> @userA++ @userA-- @userB++ @userB++ @userC++
usera goin 0 fo 1 da kine! :shaka:
Ho brah, userb 1 da kine! :shaka:
Ho brah, userc 1 da kine! :shaka:</pre>
</details>